### PR TITLE
Get info from token response instead of a new get

### DIFF
--- a/lib/omniauth/strategies/pipefy.rb
+++ b/lib/omniauth/strategies/pipefy.rb
@@ -6,23 +6,28 @@ module OmniAuth
       option :name, :pipefy
 
       option :client_options,
-             site: 'https://app.pipefy.com',
+             site: ENV.fetch('PIPEFY_URL', 'https://app.pipefy.com'),
              authorize_url: '/oauth/authorize'
 
-      uid { raw_info['resource_owner_id'] }
+       uid { user_info['id'] }
 
-      info do
-        {
-          username: raw_info['username'],
-          name: raw_info['name'],
-          email: raw_info['email'],
-          avatar: raw_info['avatar_url']
-        }
-      end
+       info do
+         {
+           user_id: user_info['id'],
+           username: user_info['username'],
+           name: user_info['name'],
+           email: user_info['email'],
+           avatar: user_info['avatar_url']
+         }
+       end
 
-      def raw_info
-        @raw_info ||= access_token.get('/oauth/token/info').parsed
-      end
+       def token_info
+         @token_info ||= access_token.to_h
+       end
+
+       def user_info
+         @user_info ||= token_info['user']
+       end
 
       def callback_url
         full_host + script_name + callback_path

--- a/spec/omniauth/strategies/pipefy_spec.rb
+++ b/spec/omniauth/strategies/pipefy_spec.rb
@@ -1,59 +1,58 @@
 require "spec_helper"
 
 describe OmniAuth::Strategies::Pipefy do
-  let(:request) { double('Request', :params => {}, :cookies => {}, :env => {}) }
-
-  subject do
-    args = ['appid', 'secret', @options || {}].compact
-    OmniAuth::Strategies::Pipefy.new(*args).tap do |strategy|
-      allow(strategy).to receive(:request) {
-        request
-      }
-    end
-  end
+  subject { OmniAuth::Strategies::Pipefy.new('appid', 'secret') }
 
   describe 'client options' do
-    it 'should have correct name' do
+    it 'has correct name' do
       expect(subject.options.name).to eq(:pipefy)
     end
 
-    it 'should have correct site' do
+    it 'has correct site' do
       expect(subject.options.client_options.site).to eq('https://app.pipefy.com')
     end
 
-    it 'should have correct authorize url' do
+    it 'has correct authorize url' do
       expect(subject.options.client_options.authorize_url).to eq('/oauth/authorize')
     end
   end
 
-  describe 'info' do
-    let(:raw_info_hash) do
+  describe 'client info' do
+    let(:token_info) do
       {
-        'username' => 'foo',
-        'name' => 'Foo Bar',
-        'email' => 'foo@example.com',
-        'avatar_url' => 'http://gravatar.com/example'
+        'user' => {
+          'id' => 123,
+          'username' => 'foo',
+          'name' => 'Foo Bar',
+          'email' => 'foo@example.com',
+          'avatar_url' => 'http://gravatar.com/example'
+        }
       }
     end
+    let(:user_info) { token_info['user'] }
 
     before do
-      allow(subject).to receive(:raw_info).and_return(raw_info_hash)
+      allow(subject).to receive(:token_info).and_return(token_info)
     end
 
-    it 'should returns the nickname' do
-      expect(subject.info['username']).to eq(raw_info_hash[:username])
+    it 'returns the id' do
+      expect(subject.info['user_id']).to eq(user_info[:id])
     end
 
-    it 'should returns the name' do
-      expect(subject.info['name']).to eq(raw_info_hash[:name])
+    it 'returns the nickname' do
+      expect(subject.info['username']).to eq(user_info[:username])
     end
 
-    it 'should returns the email' do
-      expect(subject.info['email']).to eq(raw_info_hash[:email])
+    it 'returns the name' do
+      expect(subject.info['name']).to eq(user_info[:name])
     end
 
-    it 'should returns the avatar_url' do
-      expect(subject.info['avatar']).to eq(raw_info_hash[:avatar_url])
+    it 'returns the email' do
+      expect(subject.info['email']).to eq(user_info[:email])
+    end
+
+    it 'returns the avatar_url' do
+      expect(subject.info['avatar']).to eq(user_info[:avatar_url])
     end
   end
 end


### PR DESCRIPTION
Extract all users info from the same request that creates a token.